### PR TITLE
Change deployment mechanism

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,12 +2,7 @@
 
 pipeline {
 
-    agent {
-        docker {
-            image 'node'
-            args '-u root'
-        }
-    }
+    agent any
 
     stages {
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,11 @@ pipeline {
         stage('Build') {
             steps {
                 echo 'Building...'
-                sh 'npm install'
+
+                // Build the image.
+                script {
+                    image = docker.build("jftanner/eclancy")
+                }
             }
         }
         stage('Deploy') {
@@ -22,19 +26,22 @@ pipeline {
             }
             steps {
                 script {
-                    transfers = [
-                            sshTransfer(remoteDirectory: 'eclancy', cleanRemote: true, sourceFiles: '**', execCommand: 'cd eclancy && docker-compose up --build -d')
-                    ]
+                    docker.withRegistry('https://registry.hub.docker.com', 'docker-hub-credentials') {
+                        image.push('latest')
+                    }
+                    sh 'ssh docker.tanndev.com rm -f eclancy-compose.yml'
+                    sh 'scp docker-compose.yml docker.tanndev.com:eclancy-compose.yml'
+                    sh 'ssh docker.tanndev.com docker-compose -f eclancy-compose.yml pull app'
+                    sh 'ssh docker.tanndev.com docker-compose -f eclancy-compose.yml up -d'
                 }
-                sshPublisher(failOnError: true, publishers: [sshPublisherDesc(configName: 'Tanndev Docker', transfers: transfers)])
-                slackSend channel: '@ericlclancy', color: 'good', message: 'Successfully built <https://eclancy.tanndev.com|your website>.'
+                slackSend channel: '@ericlclancy', color: 'good', message: 'Successfully published <https://eclancy.tanndev.com|your website>.'
             }
         }
     }
 
     post {
         failure {
-            slackSend channel: '@ericlclancy', color: 'danger', message: "Failed to build your website. (<${env.JOB_URL}|Pipeline>) (<${env.BUILD_URL}console|Console>)"
+            slackSend channel: '@ericlclancy', color: 'danger', message: "Failed to build/publish your website. (<${env.JOB_URL}|Pipeline>) (<${env.BUILD_URL}console|Console>)"
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    build: .
+    image: jftanner/eclancy
     container_name: eclancy
     ports:
     - 8082:8082


### PR DESCRIPTION
This PR changes the deployment mechanism to build and publish a docker image and then pull it it on the remote docker server via SSH. This reduces the amount of data to be sent over the network to the docker machine and speeds up development.

Additionally, it also makes the `jftanner/eclancy` docker image available for download in any other docker environment, as desired.

If you'd prefer to publish to your own Docker Hub account, you'll need to add the necessary credentials into Jenkins and update the docker-compose and Jenkinsfile settings accordingly.